### PR TITLE
Add activity links to lectures 7 and 8

### DIFF
--- a/content/lectures/lecture_7.rst
+++ b/content/lectures/lecture_7.rst
@@ -23,7 +23,7 @@ Using your inventor’s kit complete the :ref:`flex_data_acquisition` activity.
 
 Assignment
 ----------
-Complete the ref:`flex_data_acquisition` activity if you did not during class.
+Complete the :ref:`flex_data_acquisition` activity if you did not during class.
 Email us a plot (from the Arduino IDE, or one that you made) of your flex sensor
 flexing. **Due 9/15/16**
 

--- a/content/lectures/lecture_8.rst
+++ b/content/lectures/lecture_8.rst
@@ -22,7 +22,7 @@ Class Plan
 
 Activity
 --------
-Complete the designing a state machine activity.
+Complete the :ref:`state_machine_XRD` activity.
 
 Assignment
 ----------


### PR DESCRIPTION
Fix an activity link in lecture 7 and add a link for the state machine activity in lecture 8. Addresses #66 and #67 